### PR TITLE
Changed input type to match intended value

### DIFF
--- a/haml/index.haml
+++ b/haml/index.haml
@@ -40,7 +40,7 @@
             .box
               .field
                 %label Base Size
-                %input.base_size{type: 'text', style: 'max-width:4em;'}
+                %input.base_size{type: 'number', style: 'max-width:4em;'}
                 %span.text_muted
                   px = <span class="base_em"></span>em
 


### PR DESCRIPTION
The input type `number` offers some basic validation to allow only number to be typed. Furthermore, it shows arrow controls to increase value of 1 unit per click.